### PR TITLE
fix deprecated error for

### DIFF
--- a/src/Database/Driver/OracleBase.php
+++ b/src/Database/Driver/OracleBase.php
@@ -71,7 +71,7 @@ abstract class OracleBase extends Driver
 
         if (!empty($config['init'])) {
             foreach ((array)$config['init'] as $command) {
-                $this->connection()
+                $this->getConnection()
                      ->exec($command);
             }
         }


### PR DESCRIPTION
Deprecated Error: CakeDC\OracleDriver\Database\Driver\OracleOCI::connection() is deprecated. Use setConnection()/getConnection() instead. - ..\vendor\cakedc\cakephp-oracle-driver\src\Database\Driver\OracleBase.php, line: 74