### PR TITLE
deprecated error for CakePHP 3.7+

### DIFF
--- a/src/Database/Driver/OracleOCI.php
+++ b/src/Database/Driver/OracleOCI.php
@@ -31,7 +31,7 @@ class OracleOCI extends OracleBase
         ];
 
         $connection = new OCI8Connection($dsn, $config['username'], $config['password'], $config['flags']);
-        $this->connection($connection);
+        $this->setConnection($connection);
         return true;
 
     }

--- a/src/Database/OCI8/OCI8Statement.php
+++ b/src/Database/OCI8/OCI8Statement.php
@@ -189,7 +189,11 @@ class OCI8Statement extends \PDOStatement implements \IteratorAggregate
      */
     public function closeCursor()
     {
-        return true;
+        // JUB 21/11/2019
+        if (is_resource($this->_sth)) {
+            oci_free_cursor($this->_sth);
+        }
+        //return true;
     }
 
     public function __destruct()
@@ -443,7 +447,10 @@ class OCI8Statement extends \PDOStatement implements \IteratorAggregate
      */
     public function rowCount()
     {
-        return oci_num_rows($this->_sth);
+        // JUB 29/11/2019
+        if(is_resource($this->_sth)){
+            return oci_num_rows($this->_sth);
+        }
     }
 
     /**

--- a/src/Database/Statement/Oci8Statement.php
+++ b/src/Database/Statement/Oci8Statement.php
@@ -21,10 +21,12 @@ class Oci8Statement extends Statement
      */
     public function closeCursor()
     {
-        if (empty($this->_sth)) {
+        // JUB 21/11/2019
+        $this->_sth->closeCursor();
+        /*if (empty($this->_sth)) {
             return true;
         }
-        return true;
+        return true;*/
     }
 
     /**


### PR DESCRIPTION
Deprecated Error: CakeDC\OracleDriver\Database\Driver\OracleOCI::connection() is deprecated. Use setConnection()/getConnection() instead. - ..\cakephp-oracle-driver\src\Database\Driver\OracleOCI.php, line: 34